### PR TITLE
feat: Favorite Repository 페이지, 컴포넌트 개발

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -49,6 +49,7 @@ module.exports = {
     "import/no-unresolved": "off",
     "import/prefer-default-export": "off",
     "react/react-in-jsx-scope": "off",
-    "react/function-component-definition": "off"
+    "react/function-component-definition": "off",
+    "react/require-default-props": "off"
   },
 }

--- a/src/App.css
+++ b/src/App.css
@@ -15,12 +15,12 @@ body {
   gap: 40px;
 }
 
-.repository-search-frame {
+.common-frame {
   display: flex;
   gap: 20px;
 }
 
-.repository-list, .repository-search-form {
+.common-article {
   width: 300px;
   height: 300px;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,10 +8,22 @@ import CommonSider from './components/CommonSider';
 import CommonContent from './components/CommonContent';
 
 function App() {
+  const router = [
+    {
+      key: '/',
+      text: 'Search Repository',
+    },
+    {
+      key: '/favoriteRepository',
+      text: 'Favorite Repository',
+    },
+  ];
   return (
     <BrowserRouter>
       <Layout className="layout">
-        <CommonSider />
+        <CommonSider
+          router={router}
+        />
         <CommonContent />
       </Layout>
     </BrowserRouter>

--- a/src/components/CommonArticle.tsx
+++ b/src/components/CommonArticle.tsx
@@ -1,0 +1,11 @@
+interface Props {
+  children: string | JSX.Element | JSX.Element[];
+}
+
+const CommonArticle = ({ children }: Props) => (
+  <article className="common-article">
+    {children}
+  </article>
+);
+
+export default CommonArticle;

--- a/src/components/CommonSider.tsx
+++ b/src/components/CommonSider.tsx
@@ -1,27 +1,35 @@
 import { HddFilled, HeartFilled } from '@ant-design/icons';
 import { Layout, Menu } from 'antd';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 const { Sider } = Layout;
 
-const CommonSider = () => (
-  <Sider>
-    <div className="sider-header" />
-    <Menu theme="dark" defaultSelectedKeys={['1']}>
-      <Menu.Item key="1">
-        <Link to="/">
-          <HddFilled />
-          <span>Search Repository</span>
-        </Link>
-      </Menu.Item>
-      <Menu.Item key="2">
-        <Link to="/favoriteRepository">
-          <HeartFilled />
-          <span>Favorite Repository</span>
-        </Link>
-      </Menu.Item>
-    </Menu>
-  </Sider>
-);
+interface Route {
+  key: string;
+  text: string;
+}
+interface Props {
+  router: Route[];
+}
+
+const CommonSider = ({ router }: Props) => {
+  const pathName = useLocation().pathname;
+  return (
+    <Sider>
+      <div className="sider-header" />
+      { pathName }
+      <Menu theme="dark" defaultSelectedKeys={[pathName]}>
+        {router.map((route: Route) => (
+          <Menu.Item key={route.key}>
+            <Link to={route.key}>
+              <HddFilled />
+              <span>{route.text}</span>
+            </Link>
+          </Menu.Item>
+        ))}
+      </Menu>
+    </Sider>
+  );
+};
 
 export default CommonSider;

--- a/src/components/FavoriteRepositories.tsx
+++ b/src/components/FavoriteRepositories.tsx
@@ -1,42 +1,42 @@
-import { useState } from 'react';
-import { List } from 'antd';
-import { CloseOutlined } from '@ant-design/icons';
+import { List, Typography } from 'antd';
+import useLocalStorage from '../hooks/useLocalStorage';
+import CommonArticle from './CommonArticle';
+import RepositoryListItem from './RepositoryListItem';
 
-interface FavoriteRepoInfo {
+interface RepositoryGridInfo {
   id: number;
   name: string;
   ownerLogin: string;
 }
+interface Props {
+  onClick: () => void;
+}
 
-const FavoriteRepositories = () => {
-  const [repositories, setRepositories] = useState<FavoriteRepoInfo[]>();
-
-  const onDeleteRepo = (id: number) => {
-    console.log(`delete repo id : ${id}`);
-  };
+const FavoriteRepositories = ({ onClick }: Props) => {
+  const { Title } = Typography;
+  const [favoriteList] = useLocalStorage(
+    'FavoriteRepositories',
+    '[]',
+  );
+  const parsedFavoriteList: RepositoryGridInfo[] = JSON.parse(favoriteList) || [];
 
   return (
-    <section className="favorite-repositories">
-      <h4>
-        Favorite Repositories.
-      </h4>
+    <CommonArticle>
+      <Title level={4}>Favorite Repository</Title>
       <List
         className="favorite-repositories__body"
-        dataSource={repositories}
+        dataSource={parsedFavoriteList}
         renderItem={(item) => (
-          <List.Item
+          <RepositoryListItem
             key={item.id}
-          >
-            <div>
-              {item.ownerLogin}
-              /
-              {item.name}
-            </div>
-            <CloseOutlined onClick={() => onDeleteRepo(item.id)} />
-          </List.Item>
+            id={item.id}
+            ownerLogin={item.ownerLogin}
+            name={item.name}
+            onClick={onClick}
+          />
         )}
       />
-    </section>
+    </CommonArticle>
   );
 };
 

--- a/src/components/FavoriteRepositoriesFrame.tsx
+++ b/src/components/FavoriteRepositoriesFrame.tsx
@@ -1,0 +1,19 @@
+import FavoriteRepositories from './FavoriteRepositories';
+import IssueList from './IssueList';
+
+const FavoriteRepositoriesFrame = () => {
+  const onClickRow = () => {
+    console.log('Favorite Row Click! Fetch Data!');
+  };
+
+  return (
+    <section className="common-frame">
+      <FavoriteRepositories
+        onClick={onClickRow}
+      />
+      <IssueList />
+    </section>
+  );
+};
+
+export default FavoriteRepositoriesFrame;

--- a/src/components/IssueList.tsx
+++ b/src/components/IssueList.tsx
@@ -1,0 +1,11 @@
+import CommonArticle from './CommonArticle';
+
+const IssueList = () => (
+  <CommonArticle>
+    <div>
+      이슈들
+    </div>
+  </CommonArticle>
+);
+
+export default IssueList;

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -1,8 +1,13 @@
 import { List, message } from 'antd';
 import RepositoryListItem from './RepositoryListItem';
-import type { RepositoryGridInfo } from './RepositorySearchFormFrame';
 import useLocalStorage from '../hooks/useLocalStorage';
+import CommonArticle from './CommonArticle';
 
+interface RepositoryGridInfo {
+  id: number;
+  name: string;
+  ownerLogin: string;
+}
 interface Props {
   items: RepositoryGridInfo[] | undefined;
 }
@@ -44,7 +49,7 @@ const RepositoryList = ({ items }: Props) => {
   };
 
   return (
-    <article className="repository-list">
+    <CommonArticle>
       {contextHolder}
       <List
         itemLayout="vertical"
@@ -64,7 +69,7 @@ const RepositoryList = ({ items }: Props) => {
           />
         )}
       />
-    </article>
+    </CommonArticle>
   );
 };
 

--- a/src/components/RepositoryListItem.tsx
+++ b/src/components/RepositoryListItem.tsx
@@ -5,22 +5,27 @@ interface Props {
   id: number;
   name: string;
   ownerLogin: string;
-  isFavorite: boolean;
-  onClick: () => void;
+  isFavorite?: boolean;
+  onClick?: () => void;
 }
 
 const RepositoryListItem = (props: Props) => {
   const {
     id, ownerLogin, name, isFavorite, onClick,
   } = props;
+
   return (
     <List.Item
       key={id}
       onClick={onClick}
     >
-      <FavoriteHeartIcon
-        isFavorite={isFavorite}
-      />
+      {
+        isFavorite !== undefined && (
+          <FavoriteHeartIcon
+            isFavorite={isFavorite}
+          />
+        )
+      }
       {ownerLogin}
       /
       {name}

--- a/src/components/RepositorySearchForm.tsx
+++ b/src/components/RepositorySearchForm.tsx
@@ -1,6 +1,7 @@
 import {
   Form, Input, Button, Typography,
 } from 'antd';
+import CommonArticle from './CommonArticle';
 
 interface SearchFormProps {
   onSearchForm: (searchText: string) => void;
@@ -20,7 +21,7 @@ const RepositorySearchForm = ({ onSearchForm, onResetForm }: SearchFormProps) =>
   };
 
   return (
-    <article className="repository-search-form">
+    <CommonArticle>
       <Title level={2} type="secondary">Github 검색</Title>
       <Title level={4}>Public Repository</Title>
       <Form
@@ -54,7 +55,7 @@ const RepositorySearchForm = ({ onSearchForm, onResetForm }: SearchFormProps) =>
           </Button>
         </Form.Item>
       </Form>
-    </article>
+    </CommonArticle>
   );
 };
 

--- a/src/components/RepositorySearchFormFrame.tsx
+++ b/src/components/RepositorySearchFormFrame.tsx
@@ -4,7 +4,7 @@ import RepositorySearchForm from './RepositorySearchForm';
 import { fetchSearchRepositories } from '../api/search';
 import RepositoryList from './RepositoryList';
 
-export interface RepositoryGridInfo {
+interface RepositoryGridInfo {
   id: number;
   name: string;
   ownerLogin: string;
@@ -35,7 +35,7 @@ const RepositorySearchFormFrame = () => {
   };
 
   return (
-    <section className="repository-search-frame">
+    <section className="common-frame">
       <RepositorySearchForm
         onSearchForm={getSearchRepositories}
         onResetForm={initSearchRepositories}

--- a/src/pages/FavoriteRepository.tsx
+++ b/src/pages/FavoriteRepository.tsx
@@ -1,7 +1,7 @@
-import FavoriteRepositories from '../components/FavoriteRepositories';
+import FavoriteRepositoriesFrame from '../components/FavoriteRepositoriesFrame';
 
 const FavoriteRepository = () => (
-  <FavoriteRepositories />
+  <FavoriteRepositoriesFrame />
 );
 
 export default FavoriteRepository;


### PR DESCRIPTION
- [x] Favorite Repostory 페이지 구성
  - Search Repository 페이지와 비슷하게 구성
- [x] CurrentRoute와 메뉴가 일치하지 않는 현상 수정
  -  route와 active를 일치하도록 수정
- [x] Favorite Repository 페이지에서 사용한 `RepositoryListItem 컴포넌트 재사용`
  - RepositoryListItem 컴포넌트 props 및 조건부 렌더링 수정
- Closes: #23 